### PR TITLE
Ignore cache test generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ venv.bak/
 config.py
 cache
 .project
+
+# Test files
+cache location for * json files*.json


### PR DESCRIPTION
Add a rule to `.gitignore` to prevent accidentally committing the test-generated cache file to version control.

Closes #34